### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/near/near-verify-rs/compare/v0.1.0...v0.2.0) - 2025-04-10
+
+### Added
+
+- verify with added `output_wasm_path` field to metadata ([#4](https://github.com/near/near-verify-rs/pull/4))
+
+### Other
+
+- test reject push

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,7 +462,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "near-verify-rs"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bs58",
  "camino",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-verify-rs"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "reference implementation of nep330 1.2.0+ docker build"
 repository = "https://github.com/near/near-verify-rs"


### PR DESCRIPTION



## 🤖 New release

* `near-verify-rs`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)

### ⚠ `near-verify-rs` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field BuildInfo.output_wasm_path in /tmp/.tmpwb5eKF/near-verify-rs/src/types/contract_source_metadata/mod.rs:219

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/function_parameter_count_changed.ron

Failed in:
  near_verify_rs::logic::docker_checks::sanity::check now takes 1 parameters instead of 0, in /tmp/.tmpwb5eKF/near-verify-rs/src/logic/docker_checks/sanity.rs:9
  near_verify_rs::logic::nep330_build::run now takes 4 parameters instead of 3, in /tmp/.tmpwb5eKF/near-verify-rs/src/logic/nep330_build.rs:49
  near_verify_rs::logic::docker_checks::pull_image::check now takes 2 parameters instead of 1, in /tmp/.tmpwb5eKF/near-verify-rs/src/logic/docker_checks/pull_image.rs:7
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/near/near-verify-rs/compare/v0.1.0...v0.2.0) - 2025-04-10

### Added

- verify with added `output_wasm_path` field to metadata ([#4](https://github.com/near/near-verify-rs/pull/4))

### Other

- test reject push
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).