### PR TITLE
chore: release v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/near/near-verify-rs/compare/v0.2.0...v0.2.1) - 2025-04-10
+
+### Other
+
+- remove Cargo.lock ([#6](https://github.com/near/near-verify-rs/pull/6))
+
 ## [0.2.0](https://github.com/near/near-verify-rs/compare/v0.1.0...v0.2.0) - 2025-04-10
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-verify-rs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 description = "reference implementation of nep330 1.2.0+ docker build"
 repository = "https://github.com/near/near-verify-rs"


### PR DESCRIPTION



## 🤖 New release

* `near-verify-rs`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.1](https://github.com/near/near-verify-rs/compare/v0.2.0...v0.2.1) - 2025-04-10

### Other

- remove Cargo.lock ([#6](https://github.com/near/near-verify-rs/pull/6))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).