### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/near/near-verify-rs/compare/v0.2.1...v0.3.0) - 2025-04-22
+
+### Added
+
+- var changes, small ([#9](https://github.com/near/near-verify-rs/pull/9))
+
 ## [0.2.1](https://github.com/near/near-verify-rs/compare/v0.2.0...v0.2.1) - 2025-04-10
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-verify-rs"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 description = "reference implementation of nep330 1.2.0+ docker build"
 repository = "https://github.com/near/near-verify-rs"


### PR DESCRIPTION



## 🤖 New release

* `near-verify-rs`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `near-verify-rs` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/inherent_method_missing.ron

Failed in:
  BuildInfo::validate_build_command_on_whitelist, previously in file /tmp/.tmpSyqPLf/near-verify-rs/src/types/contract_source_metadata/validate.rs:123

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field expected_command_prefix of struct WhitelistEntry, previously in file /tmp/.tmpSyqPLf/near-verify-rs/src/types/whitelist.rs:8
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/near/near-verify-rs/compare/v0.2.1...v0.3.0) - 2025-04-22

### Added

- var changes, small ([#9](https://github.com/near/near-verify-rs/pull/9))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).