### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/near/near-verify-rs/compare/v0.3.0...v0.3.1) - 2025-05-29
+
+### Other
+
+- update snapshots to released (docker image, `cargo-near-build` package) ([#14](https://github.com/near/near-verify-rs/pull/14))
+- test [cargo_near_build::extended::build_with_cli] ([#13](https://github.com/near/near-verify-rs/pull/13))
+- factory with build-scripts, running binary `cargo-near` (no lib) ([#10](https://github.com/near/near-verify-rs/pull/10))
+- Added @frol to the CODEOWNERS
+
 ## [0.3.0](https://github.com/near/near-verify-rs/compare/v0.2.1...v0.3.0) - 2025-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/near/near-verify-rs/compare/v0.3.0...v0.3.1) - 2026-01-01
+
+### Other
+
+- Upgraded dependencies to the latest releases
+
 ## [0.3.0](https://github.com/near/near-verify-rs/compare/v0.2.1...v0.3.0) - 2025-04-22
 
 ### Added

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dj8yfo @FroVolod @akorchyn @PolyProgrammist @frol
+* @frol @akorchyn @PolyProgrammist

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-verify-rs"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "reference implementation of nep330 1.2.0+ docker build"
 repository = "https://github.com/near/near-verify-rs"
@@ -11,13 +11,13 @@ keywords = ["docker", "reproducible-build", "near", "nep330"]
 url = { version = "2.5.0", features = ["serde"] }
 serde = { version = "1.0.197" }
 eyre = "0.6.12"
-colored = "2.0"
+colored = "3"
 tracing = "0.1.40"
 shell-words = { version = "1.0.0" }
 indenter = "0.3"
 unix_path = { version = "1.0.1" }
 camino = "1.1.1"
-cargo_metadata = "0.18.1"
+cargo_metadata = "0.23"
 dunce = "1"
 unix_str = "1.0.0"
 sha2 = "0.10"
@@ -27,10 +27,10 @@ regex = "1.11.1"
 pathdiff = { version = "0.2.1", features = ["camino"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-nix = { version = "0.29.0", features = ["user", "process"] }
+nix = { version = "0.30", features = ["user", "process"] }
 
 
 [dev-dependencies]
-git2 = { version = "0.19" }
+git2 = { version = "0.20" }
 serde_json = "1.0.140"
 tempfile = { version = "3.10.1" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-verify-rs"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "reference implementation of nep330 1.2.0+ docker build"
 repository = "https://github.com/near/near-verify-rs"


### PR DESCRIPTION



## 🤖 New release

* `near-verify-rs`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/near/near-verify-rs/compare/v0.3.0...v0.3.1) - 2025-05-29

### Other

- update snapshots to released (docker image, `cargo-near-build` package) ([#14](https://github.com/near/near-verify-rs/pull/14))
- test [cargo_near_build::extended::build_with_cli] ([#13](https://github.com/near/near-verify-rs/pull/13))
- factory with build-scripts, running binary `cargo-near` (no lib) ([#10](https://github.com/near/near-verify-rs/pull/10))
- Added @frol to the CODEOWNERS
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).