### PR TITLE
chore: update `cargo_metadata` dep to enable building `cargo-near-build` with rustc v1.86

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ shell-words = { version = "1.0.0" }
 indenter = "0.3"
 unix_path = { version = "1.0.1" }
 camino = "1.1.1"
-cargo_metadata = "0.23"
+cargo_metadata = ">=0.21, <0.22"
 dunce = "1"
 unix_str = "1.0.0"
 sha2 = "0.10"


### PR DESCRIPTION
This pr addresses the issue with `cargo-near-build` not being able to compile with rustc v1.86, as `cargo-near-build` depends on `cargo-verify-rs`