### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/near/near-verify-rs/compare/v0.3.2...v0.3.3) - 2026-04-15
+
+### Fixed
+
+- Append SELinux shared relabel for the bind mount (:z) ([#22](https://github.com/near/near-verify-rs/pull/22))
+
+### Other
+
+- upgrade to Rust edition 2024 ([#20](https://github.com/near/near-verify-rs/pull/20))
+
 ## [0.3.2](https://github.com/near/near-verify-rs/compare/v0.3.1...v0.3.2) - 2026-01-13
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-verify-rs"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.86"
 description = "reference implementation of nep330 1.2.0+ docker build"


### PR DESCRIPTION



## 🤖 New release

* `near-verify-rs`: 0.3.2 -> 0.3.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.3](https://github.com/near/near-verify-rs/compare/v0.3.2...v0.3.3) - 2026-04-15

### Fixed

- Append SELinux shared relabel for the bind mount (:z) ([#22](https://github.com/near/near-verify-rs/pull/22))

### Other

- upgrade to Rust edition 2024 ([#20](https://github.com/near/near-verify-rs/pull/20))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).