### PR TITLE
ci: trusted publishing to crates.io via release-plz + OIDC

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,26 +1,73 @@
 name: Release-plz
 
-permissions:
-  pull-requests: write
-  contents: write
-
 on:
   push:
     branches:
       - main
 
+permissions: {}
+
 jobs:
-  release-plz:
-    name: Release-plz
+  release-plz-pr:
+    name: Release-plz PR
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-pr-${{ github.ref }}
+      cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          submodules: recursive
-          token: ${{ secrets.RELEASE_PLZ_GITHUB_TOKEN }}
-      - uses: MarcoIeni/release-plz-action@v0.5
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz (release-pr)
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
         env:
-          # https://release-plz.ieni.dev/docs/github/trigger
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+      id-token: write
+      attestations: write
+    # Never cancel an in-flight publish — half-published releases are worse than waiting.
+    concurrency:
+      group: release-plz-release-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz (release)
+        id: release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # release-plz doesn't expose the produced .crate path, so re-package locally.
+      # The crate tarball is reproducible from the same commit, so the attestation
+      # still binds the published artifact to this run.
+      - name: Re-package crate for attestation
+        if: steps.release-plz.outputs.releases_created == 'true'
+        run: cargo package --no-verify
+      - name: Attest build provenance
+        if: steps.release-plz.outputs.releases_created == 'true'
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: target/package/*.crate

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,14 @@
+[workspace]
+changelog_update = true
+git_tag_enable = true
+git_release_enable = true
+git_release_type = "auto"
+
+[changelog]
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""


### PR DESCRIPTION
Switches release-plz over to OIDC trusted publishing — no more `CARGO_REGISTRY_TOKEN`, and published crates get attestations. Same pattern we used on near/near-slip10#3.

Also dropped the old `MarcoIeni/release-plz-action` name (it's `release-plz/action` now) and the `RELEASE_PLZ_GITHUB_TOKEN` PAT. One small tradeoff: CI won't auto-trigger on the release-plz PR anymore, only when it merges. Slip10 made the same call.

Before this can actually release, someone needs to register `near/near-verify-rs` on crates.io as a trusted publisher pointing at `release-plz.yml`.

Refs near/devex#45